### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install httpserver
+    circup install adafruit_httpserver
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
circup install command was incorrect. Library name is `adafruit_httpserver`.